### PR TITLE
Accept tool timeout as a config variable

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,4 @@
 # Default configuration for lazy_ci
 code-quality: true
 ship: false
+tool-timeout: 9999

--- a/src/lazy_ci/code_quality.py
+++ b/src/lazy_ci/code_quality.py
@@ -6,7 +6,7 @@ import subprocess
 from loguru import logger
 
 
-def run_code_quality():
+def run_code_quality(tool_timeout=9999):
     """Run code quality checks"""
     cwd = os.getcwd()
     commands = [
@@ -36,7 +36,7 @@ def run_code_quality():
         logger.warning(os.getcwd())
         current_command = " ".join(process.args)
         try:
-            stdout, stderr = process.communicate(timeout=9999)
+            stdout, stderr = process.communicate(timeout=tool_timeout)
         except subprocess.TimeoutExpired:
             logger.error(f"Timeout on process: {current_command}")
             process.kill()

--- a/src/lazy_ci/main.py
+++ b/src/lazy_ci/main.py
@@ -15,16 +15,17 @@ def main():
     parser.add("-c", "--config", is_config_file=True, help="config file path")
     parser.add("--code-quality", help="Run code quality checks", action="store_true")
     parser.add("--ship", help="Ship code", action="store_true")
+    parser.add("--tool-timeout", help="Tool timeout in seconds", type=int, default=9999)
 
     options = parser.parse_args()
 
     if options.code_quality:
         logger.info("Running code quality checks")
-        if not run_code_quality():
+        if not run_code_quality(options.tool_timeout):
             sys.exit(1)
     elif options.ship:
         logger.info("Shipping code!")
-        if not run_code_quality():
+        if not run_code_quality(options.tool_timeout):
             logger.critical("Code quality checks failed, not shipping code!!!")
             sys.exit(1)
         else:
@@ -32,7 +33,7 @@ def main():
                 sys.exit(1)
     else:
         logger.warning("No command provided, running code quality checks as default")
-        if not run_code_quality():
+        if not run_code_quality(options.tool_timeout):
             sys.exit(1)
 
 


### PR DESCRIPTION
Related to #4

Implements the ability to configure tool timeout through `config.yml` and command line arguments, enhancing flexibility in the execution of code quality checks.

- **Configuration Update**: Adds a new key `tool-timeout` in `config.yml` with a default value of 9999 seconds, allowing users to specify a custom timeout for tools.
- **Command Line Argument**: Introduces `--tool-timeout` as a new command line argument in `src/lazy_ci/main.py`, enabling users to override the default or configured timeout value directly from the command line.
- **Functionality Enhancement**: Modifies `run_code_quality` function in `src/lazy_ci/code_quality.py` to accept `tool_timeout` as an argument and applies this timeout to subprocesses, ensuring that the tool execution respects the user-defined timeout settings.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/calvinloveland/lazy_ci/issues/4?shareId=00461fbd-e7d3-4744-8b76-e0f2c98386ea).